### PR TITLE
Tinymce not loading

### DIFF
--- a/views/shared/coverage.php
+++ b/views/shared/coverage.php
@@ -59,9 +59,9 @@
                     var textareaId = textarea.attr('id');
                     var enableIfChecked = function () {
                         if (this.checked) {
-                            tinyMCE.execCommand("mceAddControl", false, textareaId);
+                            tinyMCE.execCommand("mceAddEditor", false, textareaId);
                         } else {
-                            tinyMCE.execCommand("mceRemoveControl", false, textareaId);
+                            tinyMCE.execCommand("mceRemoveEditor", false, textareaId);
                         }
                     };
 


### PR DESCRIPTION
Tinymce v4 has updated its API, with this version the previous api call no longer works.  (latest exhibits plugin uses tinymce v4.9.4)

refer to https://www.tiny.cloud/docs/advanced/editor-command-identifiers/#editormanagementcommands

This fixes this [issue](https://github.com/scholarslab/NeatlineFeatures/issues/91).